### PR TITLE
Fix routing on GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# Built assets
+static/
+editor/

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,17 @@
+# Prep for pushing
+git branch -D gh-pages
+git checkout -b gh-pages
+
+# Build the static assets and symlink them
+npm run build
+npm run symlink
+
+# Little tweaks
+touch .nojekyll
+
+# DO IT
+git add .
+git add -f static/
+git add -f editor/
+git commit -m "Deploy the new stuff"
+git push -f origin gh-pages

--- a/bin/symlink
+++ b/bin/symlink
@@ -1,0 +1,5 @@
+# Fake the routing by setting up symlinks
+mkdir -p editor
+ln -sf ../static ./editor/static
+ln -sf ../assets ./editor/assets
+ln -sf ../index.html ./editor/index.html

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "src/index.js",
   "scripts": {
     "build": "NODE_ENV=production webpack -p --devtool=source-map",
+    "deploy": "./bin/deploy",
     "start": "babel-node server.js",
+    "symlink": "./bin/symlink",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom';
 
 import { Link } from 'react-router';
 
+import { EDITOR_PATH } from 'utils/urls';
+
 import { createPureComponent } from 'utils/createPureComponent';
 
 export default createPureComponent({
@@ -10,8 +12,8 @@ export default createPureComponent({
   displayName: 'App',
 
   renderLink() {
-    const isEditing = this.props.location.pathname === '/editor';
-    const to = isEditing ? '/' : '/editor';
+    const isEditing = this.props.location.pathname.indexOf(EDITOR_PATH) > -1;
+    const to = isEditing ? '/' : EDITOR_PATH;
     const text = isEditing ? 'Play this level' : 'Edit this level';
     return (<Link to={to}>{text}</Link>);
   },

--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom';
 
 import { createPureComponent } from 'utils/createPureComponent';
 
+import { gridColsToPx } from 'utils/gridCoordsToStyle';
+
 import Camera from 'components/Camera/Camera';
 import Corngratulations from 'components/Corngratulations/Corngratulations';
 import HudContainer from 'components/Hud/HudContainer';
@@ -29,9 +31,10 @@ export default createPureComponent({
   render() {
     const { hasWon, numCols, numRows } = this.props;
     const corngrats = hasWon && (<Corngratulations />);
+    const style = { maxWidth: gridColsToPx(numCols) }
 
     return (
-      <div className="game">
+      <div className="game" style={style}>
         <Camera numCols={numCols} numRows={numRows}>
           <WorldContainer>
             <PlayerContainer />

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ import { IndexRoute, Route } from 'react-router';
 
 import createStore from 'utils/createStore';
 
+import { EDITOR_PATH } from 'utils/urls';
+
 import { toChangeLevel } from 'state/actions/changeLevel';
 
 import App from 'components/App/App';
@@ -27,7 +29,7 @@ const app = (
     <ReduxRouter>
       <Route path="/" component={App}>
         <IndexRoute component={GameContainer} />
-        <Route path="editor" component={EditorContainer} />
+        <Route path={EDITOR_PATH} component={EditorContainer} />
         <Route path="*" component={GameContainer} />
       </Route>
     </ReduxRouter>

--- a/src/utils/createStore.js
+++ b/src/utils/createStore.js
@@ -1,4 +1,7 @@
-import { createHistory } from 'history';
+import {
+  createHistory,
+  useBasename
+} from 'history';
 
 import {
   compose,
@@ -13,9 +16,18 @@ import {
 
 import thunk from 'redux-thunk';
 
+import { BASE_PATH } from 'utils/urls';
+
 import * as appReducer from 'state';
 
 import { initialState } from 'state/initialState';
+
+const createHistoryWithBasename = (opts = {}) => {
+  return useBasename(createHistory)({
+    ...opts,
+    basename: `/${BASE_PATH}`
+  });
+};
 
 const routerStateSelector = (state) => state.get('router');
 
@@ -31,6 +43,6 @@ const reducer = (state = initialState, action) => {
 export default function createStore() {
   return compose(
     applyMiddleware(thunk),
-    reduxReactRouter({ createHistory, routerStateSelector })
+    reduxReactRouter({ createHistory: createHistoryWithBasename, routerStateSelector })
   )(createReduxStore)(reducer);
 };

--- a/src/utils/gridCoordsToStyle.js
+++ b/src/utils/gridCoordsToStyle.js
@@ -3,16 +3,24 @@ import {
   PX_PER_COL
 } from 'utils/constants';
 
+export function gridColsToPx(cols) {
+  return `${PX_PER_COL * cols}px`;
+};
+
+export function gridRowsToPx(rows) {
+  return `${PX_PER_ROW * rows}px`
+};
+
 export function gridCoordsToOffsetStyle(row, col) {
   return {
-    top: `${PX_PER_ROW * row}px`,
-    left: `${PX_PER_COL * col}px`,
+    top: gridRowsToPx(row),
+    left: gridColsToPx(col),
   };
 };
 
 export function gridCoordsToDimStyle(numCols, numRows) {
   return {
-    height: `${PX_PER_ROW * numRows}px`,
-    width: `${PX_PER_COL * numCols}px`,
+    height: gridRowsToPx(numRows),
+    width: gridColsToPx(numCols),
   };
 };

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -1,0 +1,5 @@
+export const EDITOR_PATH = 'editor';
+export const BASE_PATH = window.location.pathname
+  .replace(`${EDITOR_PATH}`, '')
+  .replace(/^\/+/, '')
+  .replace(/\/+$/, '');


### PR DESCRIPTION
Fixes #13, supersedes #14.

- Fixes a small style issue, unrelated to this PR as a whole but I'm slapping it in there
- Adds `deploy` script which is also largely unrelated to this PR. It's been something I've been intending to add for a while. The symlinking that happens in it is relevant to this PR though.
- Adds a `symlink` script from @codingcampbell's idea in #14
- Leverages `useBasename`, also from #14 
- Adds and uses some path constants