### PR TITLE
Use Twemoji on non-Mac platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-transform-hmr": "^1.0.1",
     "sass-loader": "^3.1.1",
     "style-loader": "^0.13.0",
+    "twemoji": "^1.4.1",
     "webpack": "^1.12.3",
     "webpack-dev-middleware": "^1.2.0",
     "webpack-hot-middleware": "^2.4.1"

--- a/src/components/Entities/Entity.scss
+++ b/src/components/Entities/Entity.scss
@@ -5,69 +5,89 @@
   font: #{$cellSize}/#{$cellSize} "Apple Color Emoji";
   z-index: 1;
 
-  &--ambulance::before  { content: "🚑"; }
-  &--banana::before     { content: "🍌"; }
-  &--bee::before        { content: "🐝"; }
-  &--bike::before       { content: "🚴"; }
-  &--boots::before      { content: "👢"; }
-  &--building::before   { content: "🏢"; }
-  &--cactus::before     { content: "🌵"; }
-  &--camel::before      { content: "🐫"; }
-  &--carA::before       { content: "🚗"; }
-  &--carB::before       { content: "🚙"; }
-  &--chicken::before    { content: "🐣"; }
-  &--chopper::before    { content: "🚁"; }
-  &--cloud::before      { content: "☁"; }
-  &--corn::before       { content: "🌽"; }
-  &--creepsun::before   { content: "🌞"; }
-  &--dancer::before     { content: "💃"; }
-  &--door::before       { content: "🚪"; }
-  &--elephant::before   { content: "🐘"; }
-  &--fire::before       { content: "🔥"; }
-  &--firetruck::before  { content: "🚒"; }
-  &--fishA::before      { content: "🐟"; }
-  &--fishB::before      { content: "🐠"; }
-  &--flowerA::before    { content: "🌻"; }
-  &--flowerB::before    { content: "🌹"; }
-  &--flowerC::before    { content: "🌷"; }
-  &--gator::before      { content: "🐊"; }
-  &--ghost::before      { content: "👻"; }
-  &--hammer::before     { content: "🔨"; }
-  &--heart::before      { content: "❤️"; }
-  &--houseA::before     { content: "🏠"; }
-  &--houseB::before     { content: "🏡"; }
-  &--invisible::before  { content: "  "; }
-  &--leavesA::before    { content: "🍃"; }
-  &--leavesB::before    { content: "🍂"; }
-  &--leavesC::before    { content: "🌿"; }
-  &--mart::before       { content: "🏪"; }
-  &--monkey::before     { content: "🐒"; }
-  &--musichall::before  { content: "🏫"; }
-  &--palm::before       { content: "🌴"; }
-  &--person::before     { content: "🏃"; }
-  &--personWalk::before { content: "🚶"; }
-  &--police::before     { content: "🚓"; }
-  &--rabbit::before     { content: "🐇"; }
-  &--santa::before      { content: "🎅"; }
-  &--shell::before      { content: "🐚"; }
-  &--shit::before       { content: "💩"; }
-  &--silverware::before { content: "🍴"; }
-  &--snake::before      { content: "🐍"; }
-  &--snowflake::before  { content: "❄"; }
-  &--snowman::before    { content: "⛄️"; }
-  &--speedboat::before  { content: "🚤"; }
-  &--moai::before       { content: "🗿"; }
-  &--sun::before        { content: "☀"; }
-  &--sunglasses::before { content: "👓"; }
-  &--tape::before       { content: "📼"; }
-  &--taxi::before       { content: "🚕"; }
-  &--tornado::before    { content: "💨"; }
-  &--treeA::before      { content: "🌲"; }
-  &--treeB::before      { content: "🎄"; }
-  &--treeC::before      { content: "🌳"; }
-  &--turtle::before     { content: "🐢"; }
-  &--wave::before       { content: "🌊"; }
-  &--willows::before    { content: "🌾"; }
+  .twemoji &::before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-size: auto;
+  }
+
+  $entities: (
+    ambulance: "🚑",
+    banana: "🍌",
+    bee: "🐝",
+    bike: "🚴",
+    boots: "👢",
+    building: "🏢",
+    cactus: "🌵",
+    camel: "🐫",
+    carA: "🚗",
+    carB: "🚙",
+    chicken: "🐣",
+    chopper: "🚁",
+    cloud: "☁",
+    corn: "🌽",
+    creepsun: "🌞",
+    dancer: "💃",
+    door: "🚪",
+    elephant: "🐘",
+    fire: "🔥",
+    firetruck: "🚒",
+    fishA: "🐟",
+    fishB: "🐠",
+    flowerA: "🌻",
+    flowerB: "🌹",
+    flowerC: "🌷",
+    gator: "🐊",
+    ghost: "👻",
+    hammer: "🔨",
+    heart: "❤️",
+    houseA: "🏠",
+    houseB: "🏡",
+    invisible: "  ",
+    leavesA: "🍃",
+    leavesB: "🍂",
+    leavesC: "🌿",
+    mart: "🏪",
+    monkey: "🐒",
+    musichall: "🏫",
+    palm: "🌴",
+    person: "🏃",
+    personWalk: "🚶",
+    police: "🚓",
+    rabbit: "🐇",
+    santa: "🎅",
+    shell: "🐚",
+    shit: "💩",
+    silverware: "🍴",
+    snake: "🐍",
+    snowflake: "❄",
+    snowman: "⛄",
+    speedboat: "🚤",
+    moai: "🗿",
+    sun: "☀",
+    sunglasses: "👓",
+    tape: "📼",
+    taxi: "🚕",
+    tornado: "💨",
+    treeA: "🌲",
+    treeB: "🎄",
+    treeC: "🌳",
+    turtle: "🐢",
+    wave: "🌊",
+    willows: "🌾"
+  );
+
+  @each $entity, $value in $entities {
+    &--#{$entity}::before { content: $value; }
+
+    .twemoji &--#{$entity}::before {
+      content: '';
+      background-image: twemoji-url($value);
+    }
+  }
 
   &--storesign--v,
   &--storesign--i,

--- a/src/components/World/World.js
+++ b/src/components/World/World.js
@@ -1,8 +1,11 @@
 import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 
+import classNames from 'classnames';
+
 import { createPureComponent } from 'utils/createPureComponent';
 import { gridCoordsToOffsetStyle } from 'utils/gridCoordsToStyle';
+import hasEmoji from 'utils/hasEmoji';
 
 import EntitiesContainer from 'components/Entities/EntitiesContainer';
 import GroundsContainer from 'components/Grounds/GroundsContainer';
@@ -21,8 +24,9 @@ export default createPureComponent({
   render() {
     const { col, row, children } = this.props;
     const style = gridCoordsToOffsetStyle(row, col);
+    const className = classNames('world', { twemoji: !hasEmoji });
     return (
-      <div className="world" style={style}>
+      <div className={className} style={style}>
         <EntitiesContainer />
         <GroundsContainer />
         {children}

--- a/src/utils/hasEmoji.js
+++ b/src/utils/hasEmoji.js
@@ -1,0 +1,1 @@
+export default navigator.platform === 'MacIntel';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
 var path = require('path');
 var webpack = require('webpack');
+var sassTypes = require('node-sass').types;
+var twemoji = require('twemoji');
 
 module.exports = {
   devtool: 'eval-source-map',
@@ -25,7 +27,15 @@ module.exports = {
       include: path.join(__dirname, 'src')
     }, {
       test: /\.scss$/,
-      loaders: ['style', 'css', 'autoprefixer', 'sass']
+      loaders: ['style', 'css', 'autoprefixer', 'sass?config=sassConfig']
     }]
+  },
+  sassConfig: {
+    functions: {
+      'twemoji-url': function(emoji) {
+        const codePoint = twemoji.convert.toCodePoint(emoji.getValue());
+        return sassTypes.String(`url(${twemoji.base}svg/${codePoint}.svg)`);
+      }
+    }
   }
 };


### PR DESCRIPTION
**Sorry for way too many screenshots ahead** here is a TLDR:

---

I am proposing non-OSX platforms get an SVG fallback. I implemented this with [twemoji](https://github.com/twitter/twemoji) because it looks nice and comes with a node API that converts emoji characters into the right URL. If a browser platform isn't `MacIntel`, a `twemoji` class gets added to `World` which replaces the `::before content` with `::before background-image`

As of now I could not get this to work on the HUD (the icons took over the screen..), so I could use some help there if it's important.

---

I use Xubuntu most of the time which is unfortunately very bad at emoji fonts. Even after porting over fonts that can render the symbols, they are solid color :cry: Check it out:

![screenshot - 01032016 - 02 57 56 pm](https://cloud.githubusercontent.com/assets/311270/12080591/7766ac18-b22d-11e5-8cf2-6e63288fbd70.png)

Windows support is a little better with color (at least, the bees seem to be not monochrome):

![emoji-windows](https://cloud.githubusercontent.com/assets/311270/12080603/ca146a54-b22d-11e5-9d6a-51a095eeb86d.png)

But it still doesn't look as good as OSX. So in this PR I am proposing all non-OSX gets an SVG fallback. Fortunately MaxCDN hosts [twemoji](https://github.com/twitter/twemoji) which looks pretty good:

![screenshot - 01032016 - 02 57 43 pm](https://cloud.githubusercontent.com/assets/311270/12080614/08ad44a2-b22e-11e5-9d0a-8241ee7aa588.png)

Curiously, they don't seem to have a snowman, but this still looks a heckuvalot better than vanilla Linux:

![screenshot - 01032016 - 02 58 36 pm](https://cloud.githubusercontent.com/assets/311270/12080623/1cd90c7c-b22e-11e5-87fe-7cb596f45799.png)
